### PR TITLE
chore: tailor CODEOWNERS for Dependabot (engineering-platform)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Dependabot dependency manifests — @vantage-sh/engineering-platform
+# Tailored from .github/dependabot.yml + repo manifests (ecosystems: github-actions, pip).
+/.github/workflows/**/* @vantage-sh/engineering-platform
+/Pipfile @vantage-sh/engineering-platform
+/Pipfile.lock @vantage-sh/engineering-platform
+/poetry.lock @vantage-sh/engineering-platform
+/pyproject.toml @vantage-sh/engineering-platform
+/requirements.txt @vantage-sh/engineering-platform


### PR DESCRIPTION
Assign `@vantage-sh/engineering-platform` as CODEOWNERS for Dependabot-related paths only (from `.github/dependabot.yml` plus repo manifest inference).

- **core**: updates `config/teams/engineering_platform.yml` and regenerated `.github/CODEOWNERS` entries for bundler, npm, docker, and docker-compose; GitHub Actions remain under existing `.github/**/*` ownership.
- **Other repos**: `.github/CODEOWNERS` lists only manifests for the ecosystems this repo uses.

Regenerate across the org later with: `node generate-tailored-dependabot-codeowners.mjs` at the ghorg root (repos other than `core`).

Made with [Cursor](https://cursor.com)

Related to PLA-1407